### PR TITLE
Fix/Android callbacks not working in some cases

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,7 +125,7 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.google.android.gms:play-services-location:19.0.1'
+  implementation 'com.google.android.gms:play-services-location:20+'
 // From node_modules
 }
 

--- a/android/src/main/java/com/reactnativebaactivitymonitor/TransitionsReceiver.java
+++ b/android/src/main/java/com/reactnativebaactivitymonitor/TransitionsReceiver.java
@@ -12,8 +12,10 @@ import android.util.Log;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.google.android.gms.location.ActivityRecognitionResult;
 import com.google.android.gms.location.ActivityTransitionEvent;
 import com.google.android.gms.location.ActivityTransitionResult;
+import com.google.android.gms.location.DetectedActivity;
 
 public class TransitionsReceiver extends BroadcastReceiver {
 
@@ -40,14 +42,14 @@ public class TransitionsReceiver extends BroadcastReceiver {
       return;
     }
 
-    if (ActivityTransitionResult.hasResult(intent)) {
-      ActivityTransitionResult result = ActivityTransitionResult.extractResult(intent);
+    if (ActivityRecognitionResult.hasResult(intent)) {
+      ActivityRecognitionResult result = ActivityRecognitionResult.extractResult(intent);
       WritableArray activities = Arguments.createArray();
 
-      for (ActivityTransitionEvent event : result.getTransitionEvents()) {
+      for (DetectedActivity detectedActivity : result.getProbableActivities()) {
         WritableMap activity = Arguments.createMap();
-        activity.putString("type", ActivityUtils.mapActivityType(event.getActivityType()));
-        activity.putString("transitionType", ActivityUtils.mapTransitionType(event.getTransitionType()));
+        activity.putString("type", ActivityUtils.mapActivityType(detectedActivity.getType()));
+        activity.putDouble("confidence", detectedActivity.getConfidence());
         activities.pushMap(activity);
       }
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,8 +10,8 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text>
-        Activity: {activity?.type ?? '...'} - Type:{' '}
-        {activity?.transitionType ?? '...'}
+        Activity: {activity?.type ?? '...'} - Confidence:{' '}
+        {activity?.confidence ?? '...'}
       </Text>
 
       <Text style={{ marginTop: 10 }}>State: {started ? 'ON' : 'OFF'}</Text>
@@ -64,11 +64,11 @@ export default function App() {
             ActivityMonitor.mockActivities([
               {
                 type: 'in-vehicle',
-                transitionType: 'enter',
+                confidence: 95,
               },
               {
                 type: 'walking',
-                transitionType: 'exit',
+                confidence: 31,
               },
             ]);
           }}

--- a/ios/BaActivityMonitor.swift
+++ b/ios/BaActivityMonitor.swift
@@ -61,7 +61,7 @@ class BaActivityMonitor: RCTEventEmitter {
     
     @objc(sendMockActivities:)
     func sendMockActivities(_ activities: NSArray) {
-        
+        self.sendEvent(withName: "activities", body: activities)
     }
 
     override func supportedEvents() -> [String]! {

--- a/ios/CMMotionActivity+Extensions.swift
+++ b/ios/CMMotionActivity+Extensions.swift
@@ -25,7 +25,20 @@ extension CMMotionActivity {
     var jsObject: NSDictionary {
         NSDictionary(dictionary: [
             "type": self.jsType,
-            "transitionType": self.jsTransitionType
+            "confidence": self.confidence.normalizedConfidence
         ])
     }
+}
+
+extension CMMotionActivityConfidence {
+    
+    var normalizedConfidence: Int {
+        switch(self) {
+        case .high: return 100
+        case .medium: return 66
+        case .low: return 33
+        default: return 0
+        }
+    }
+    
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,6 @@ const BaActivityMonitor = NativeModules.BaActivityMonitor
       }
     );
 
-export type ActivityTransitionType = 'enter' | 'exit';
 export type ActivityType =
   | 'in-vehicle'
   | 'on-bicycle'
@@ -110,7 +109,7 @@ export function askPermission(): Promise<PermissionResult> {
 }
 
 /**
- * Sends mock activities to simulate the native incoming activity transition. Used for testing.
+ * Sends mock activities to simulate the native incoming activity. Used for testing.
  * @param activities the activities to mock
  */
 export function mockActivities(activities: Activity[]) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,7 +27,7 @@ export type ActivityType =
 
 export interface Activity {
   type: ActivityType;
-  transitionType: ActivityTransitionType;
+  confidence: number;
 }
 
 export type OnActivityCallback = (activities: Activity[]) => void;


### PR DESCRIPTION
# Discussion

Fixes issue 1

https://github.com/googlecodelabs/activity_transitionapi-codelab/issues/9

Seems likely that the `ActivityTransitionAPI` is a bit buggy, doesn't work all the times, so I re-implemented using the `ActivityRecognitionAPI` which is a bit lower level and lets the developer decides whether to use the value or not. The transition type `'enter' | 'exit'` is no longer used thus it was removed. Now the `confidence` prop is available, which is an integer that goes from 0 to 100 (on iOS it only has 3 values, 33, 66, and 100 representing low medium and high confidence).

# Stories

n/a

# Changes

- [x] ActivityTransitionApi -> ActivityRecognitionApi
- [x] Remove `transitionType`
- [x] Adds `confidence`
- [x] iOS Mock
- [x] Docs updates

# Evidence

n/a