### PR TITLE
fix: handle catalyst reload

### DIFF
--- a/android/src/main/java/com/reactnativebaactivitymonitor/BaActivityMonitorModule.java
+++ b/android/src/main/java/com/reactnativebaactivitymonitor/BaActivityMonitorModule.java
@@ -79,6 +79,11 @@ public class BaActivityMonitorModule extends ReactContextBaseJavaModule implemen
         return NAME;
     }
 
+    @Override
+    public void onCatalystInstanceDestroy() {
+        this.stop();
+    }
+
     public boolean isAllowedToTrackActivities() {
         if (runningQOrLater) {
             return PackageManager.PERMISSION_GRANTED == ActivityCompat.checkSelfPermission(

--- a/ios/BaActivityMonitor.swift
+++ b/ios/BaActivityMonitor.swift
@@ -68,4 +68,8 @@ class BaActivityMonitor: RCTEventEmitter {
         return ["activities"]
     }
     
+    override func invalidate() {
+        self.stop()
+    }
+    
 }


### PR DESCRIPTION
# Discussion

fixes an android bug

```

2022-10-27 19:05:50.841 7071-7071/com.cardata E/unknown:ReactContextBaseJavaModule: Unhandled SoftException
    java.lang.RuntimeException: Catalyst Instance has already disappeared: requested by Timing
        at com.facebook.react.bridge.ReactContextBaseJavaModule.getReactApplicationContextIfActiveOrWarn(ReactContextBaseJavaModule.java:66)
        at com.facebook.react.modules.core.TimingModule.access$000(TimingModule.java:22)
        at com.facebook.react.modules.core.TimingModule$BridgeTimerExecutor.callTimers(TimingModule.java:28)
        at com.facebook.react.modules.core.JavaTimerManager$TimerFrameCallback.doFrame(JavaTimerManager.java:84)
        at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:175)
        at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:85)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:970)
        at android.view.Choreographer.doCallbacks(Choreographer.java:796)
        at android.view.Choreographer.doFrame(Choreographer.java:727)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:957)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

# Stories

n/a

# Changes

- [x] Catalyst destroy handler

# Evidence

n/a